### PR TITLE
Refresh public project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,57 @@
-<p align="center">
-  <a href="" rel="noopener">
- <img width=300px src="./express_app/public/assests/logoRidex.png" alt="Ridex-logo"></a>
-</p>
+﻿# RideX
 
-<h3 align="center">Decentralized Taxi System</h3>
+RideX is a ride-hailing prototype with an Express application, EJS views, controller-based rider and driver flows, and a Solidity contract artifact.
 
-<div align="center">
-  <h3> Problem Statement</h3>
-  <p>In most of the cities which have a wide local auto and taxi network deny ola and uber to enter that town/city/place. As drivers fear of slavery and reduced income, losing ownership and independence.</p>
-</div>
+## Repository Status
 
-------------------------------------------
-### Medium Articles
-<a href="https://medium.com/@someshdesign/ridex-taxi-service-on-ethereum-blockchain-adb077fc818c" target="_blank">RideX | Taxi service on Ethereum Blockchain</a>
-<br>
-<a href="https://uxplanet.org/ridex-taxi-service-on-ethereum-blockchain-fecee1879a23" target="_blank">RideX | Taxi service on Ethereum Blockchain — a Design case study</a>
+- Current role: Ride-hailing prototype exploring rider, driver, trip, and contract-backed settlement concepts
+- Documentation status: refreshed for public review
+- Primary audience: engineers, product reviewers, and collaborators evaluating the project context
 
+## What This Project Does
 
+- Express application with server-rendered views
+- Rider and driver workflow controllers
+- Trip-oriented views and route handling
+- Solidity contract artifact for decentralized settlement exploration
 
-------------------------------------------
-### Solution
+## Technology Stack
 
-- `Decentralization` This platform will remove the centralized transaction fee (payment gateway)and also the platform fee (uber or ola) and allows drivers and commuters to register directly. 
-- `Transparency` When a user request cab for a trip, drivers nearby will be notified with the trip and they can start bidding, the user can choose the least bid and start the ride, having a Local Fare Estimator will really help people who are new to the city and can avoid being cheated.
-- Drivers need not pay commissions to Cab hailing platforms
-- Users need not pay high surge prices
-- Tax grip for govt
+- Node.js and Express
+- EJS templates
+- Solidity contract under Contract/
+- Static assets and view-driven application structure
 
-------------------------------------------
-### Issues
+## Repository Map
 
- - `Bargaining with Autowala's` Users find it timeconsuming and useless to bargain for reducing the prices quoted by normal cab or auto wala (High prices are quoted because their business is hindered by ola and uber so they try to make as much money as possible in one single ride).
- - `Decentralized Payments` Users are more satisfied with digital payments rather than cash along with the partner offers delivered to a user.
- - `Cheat on Fares` Native ppl know better insights about fares of their own states and places. But a guy from other state visiting Kerala will have no idea about the local fares but will prefer ola and uber for a nominal price.
- - `Transparency for Govt.` As and when many country's local Govt. are asking Ola and Uber to comply with local rules which might hinder their earnings and net profit. After a few years, the prices may be the same or more than the local taxi vendors.
+- express_app/ contains the web application
+- Contract/ contains the smart contract artifact
+- RideX.gif provides a visual demo asset
+- README.md captures original project context
 
+## Getting Started
 
-<div align="center">
+- Install Node.js and npm in the Express app directory
+- Run npm install where package metadata is present
+- Configure local values with safe placeholders
+- Start the Express app for local review
+- Use contract tooling only in a local development network
 
-<h3 > RideX </h3>
-<br>
-<p align="center">
-<img src ="RideX.gif" width = 500px>
-</p>
+## Documentation
 
-</div>
+- docs/overview.md - product context, users, scope, and outcomes
+- docs/architecture.md - components, data flow, and sequence diagrams
+- docs/product.md - user journeys, requirements, constraints, and roadmap ideas
+- docs/operations.md - setup, validation, maintenance, and known risks
 
-------------------------------------------
+## Known Limitations
 
-### Add-Ons
+- Prototype does not represent production routing, payments, identity verification, or safety workflows
+- Contract-backed settlement needs rigorous threat modeling
+- Real ride-hailing requires geospatial accuracy and operational support design
 
-- [ ] RideShare
-- [ ] Optimal prize : How do you fix the optimal price for a ride (Factors like fuel price, demand, local fare)
-- [ ] Currency Conversion : How does the driver convert his cryptos into local currency
-- [ ] Reputation Layer : How does RideX take care of bad drivers via Feedback
-- [ ] Seamless Verification : Driver KYC
-- [ ] Usage of Decentralized Location Service ( FOAM ) 
+## Notes For Future Maintainers
 
-------------------------------------------
-### File Structure
+This repository documents the original project intent and the implementation shape visible in the codebase. Before production use, review dependencies, environment configuration, data handling, and deployment assumptions against current standards.
 
-
-#### WebApp
-
-- `express_app` : Source code for website
-- `Contracts` : Smart Contracts.
-
-#### App
-
-- Repository [here](https://github.com/priyamshah112/RideX/tree/app)
-
-------------------------------------------
-### Installation
-
-* Install dependencies
-```sh
-        $ npm install 
-```
-
-* Create a infura account and link infura ropsten api key.
-
-
-------------------------------------------
-### Contributing
-
- We're are open to `enhancements` & `bug-fixes` :smile: Also do have a look [here](./CONTRIBUTING.md)
-
-### Note
-
-- This project was done under `36 hours with minimal pre-preparation`
-
-------------------------------------------
-### Contributors
-
-- [@devanshslnk](https://github.com/devanshslnk)
-- [@priyamshah112](https://github.com/priyamshah112)
-- [@Remo-Somesh](https://github.com/Remo-Somesh)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,44 @@
+﻿# Architecture
+
+RideX uses a server-rendered Express application for ride workflows and keeps the contract concept separate from the application shell.
+
+## Component View
+
+```mermaid
+flowchart LR
+  Actor["Rider or driver"] --> Entry["Express views"]
+  Entry --> Service["Ride workflow controllers"]
+  Service --> Data["Application state"]
+  Service --> External["Solidity contract concept"]
+```
+
+## Key Components
+
+- EJS views for rider and driver surfaces
+- Express controllers for trip workflows
+- Static demo assets
+- Solidity contract artifact
+
+## Main Workflow
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Client
+  participant App
+  participant Store
+  User->>Client: Starts or accepts a ride request
+  Client->>App: Submits trip action
+  App->>Store: Validate and persist state
+  Store-->>App: Trip state updated
+  App-->>Client: Returns updated ride view
+  Client-->>User: Present updated result
+```
+
+## Design Considerations
+
+- Separate rider and driver responsibilities clearly
+- Model trip state as a lifecycle
+- Treat location, pricing, and safety as first-class future concerns
+
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,31 @@
+﻿# Operations
+
+These notes capture the practical work needed to run, maintain, or modernize the repository from its current state.
+
+## Local Operation
+
+- Install Node.js and npm in the Express app directory
+- Run npm install where package metadata is present
+- Configure local values with safe placeholders
+- Start the Express app for local review
+- Use contract tooling only in a local development network
+
+## Validation
+
+- Smoke-test the Express views locally
+- Review route handlers for expected trip state transitions
+- Use only local contract networks for experimentation
+
+## Maintenance Notes
+
+- Document Node.js version and start command
+- Keep demo assets separate from source logic
+- Avoid coupling settlement experiments to rider UX
+
+## Operational Risks
+
+- Prototype does not represent production routing, payments, identity verification, or safety workflows
+- Contract-backed settlement needs rigorous threat modeling
+- Real ride-hailing requires geospatial accuracy and operational support design
+
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,27 @@
+﻿# Overview
+
+The project explores the operational core of a ride marketplace: rider requests, driver acceptance, trip state, and settlement concepts.
+
+## Problem Space
+
+Ride marketplaces coordinate identity, availability, route context, price expectations, and trust between two sides of a time-sensitive transaction.
+
+## Primary Users
+
+- Riders requesting transportation
+- Drivers accepting ride opportunities
+- Operators monitoring marketplace state
+
+## Scope
+
+- Ride request and acceptance concepts
+- Rider and driver web flows
+- Contract-backed settlement exploration
+
+## Outcomes To Evaluate
+
+- Two-sided marketplace flow is understandable
+- Trip lifecycle can be explained without relying on code details
+- Production gaps are explicit
+
+

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,0 +1,29 @@
+﻿# Product Notes
+
+The product framing is a two-sided mobility workflow where trust and timing matter more than decorative UI.
+
+## User Journeys
+
+- Rider requests a ride and waits for acceptance
+- Driver reviews and accepts a ride opportunity
+- Trip state moves from request to completion
+
+## Functional Requirements
+
+- Represent rider and driver roles
+- Track request, acceptance, and completion state
+- Surface clear trip status in the interface
+
+## Constraints
+
+- Real deployment requires maps, pricing, payments, identity, and safety infrastructure
+- Blockchain settlement should not slow down core trip UX
+- Operational support must handle cancellations and disputes
+
+## Roadmap Ideas
+
+- Add trip state machine documentation
+- Introduce map and route abstraction
+- Add local contract tests and non-contract payment alternative notes
+
+


### PR DESCRIPTION
## Summary
- Refresh the public README with a neutral project overview, stack, setup notes, and limitations.
- Add standard documentation under docs/ where useful: overview, architecture, product, and operations.
- Keep the content professional and repository-focused without strategy-specific document names.

## Validation
- Documentation-only change.
- Verified README docs links locally across the refresh batch.